### PR TITLE
Tweak & Optimize CI/CD configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,12 @@
-version: 2
+version: 2.1
 
 jobs:
   build:
     working_directory: ~/circleci-pichupido
     docker:
-      - image: circleci/node:12.14.1
+      - image: cimg/node:12.14.1
     steps:
       - checkout
-      - setup_remote_docker
       - restore_cache:
           key: dependency-cache-{{ .Branch }}-{{ checksum "package.json" }}
       - run:
@@ -27,12 +26,9 @@ jobs:
           name: Build project
           command: npm run build
   deploy:
-    branches:
-      only:
-        - master
     working_directory: ~/circleci-pichupido
-    docker:
-      - image: circleci/node:12.14.1
+    machine:
+      image: ubuntu-2004:202008-01
     steps:
       - run:
           name: Deploy to Docker Cloud
@@ -43,9 +39,12 @@ jobs:
             apt-get update && apt-get install curl
             curl -X PATCH https://api.heroku.com/apps/pichupido/formation --header "Content-Type: application/json" --header "Accept: application/vnd.heroku+json; version=3.docker-releases" --header "Authorization: Bearer ${HEROKU_TOKEN}" --data '{ "updates": [ { "type": "web", "docker_image": "'$(cat imageid.txt)'" } ] }'
 workflows:
-  server:
-    jobs:
-      - build:
-      - deploy:
-          requires:
-            - build
+  jobs:
+    - build
+    - deploy:
+        filters:
+          branches:
+            only:
+              - master
+        requires:
+          - build


### PR DESCRIPTION
Moves to newer "cimg" Docker images, which are smaller and faster than the previous generation of "circleci" images. Also drops the remote docker setup during the build job and uses a machine executor in the deploy job for native docmer building.

Bumping `version` stanza to 2.1, which is the latest version :)